### PR TITLE
Deploy unified datamasque/app image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This repository contains Terraform templates for deploying DataMasque on ECS.
 Container images for the DataMasque application running on ECS are available in DataMasque's public ECR:
 
 - `public.ecr.aws/u4t6n7u6/datamasque/admin-frontend`
-- `public.ecr.aws/u4t6n7u6/datamasque/admin-server`
-- `public.ecr.aws/u4t6n7u6/datamasque/agent`
+- `public.ecr.aws/u4t6n7u6/datamasque/app`
 - `public.ecr.aws/u4t6n7u6/datamasque/agent-queue`
 - `public.ecr.aws/u4t6n7u6/datamasque/in-flight-server`
 
@@ -45,8 +44,7 @@ If using private ECR, create the following Amazon ECR repositories:
 
 - `<ECR host>/<prefix>/admin-db`
 - `<ECR host>/<prefix>/admin-frontend`
-- `<ECR host>/<prefix>/admin-server`
-- `<ECR host>/<prefix>/agent`
+- `<ECR host>/<prefix>/app`
 - `<ECR host>/<prefix>/agent-queue`
 - `<ECR host>/<prefix>/in-flight-server`
 
@@ -108,9 +106,9 @@ ecs:
       albCertificate: xxxx-xxxx-xxxx-xxxx-xxxx  # UUID of the certificate in AWS Certificate Manager
       ecr:
         ecrRepoName: datamasque
-        ecrImageTag: 2-28-0-final-xxxxx  # DataMasque image tag
+        ecrImageTag: 3-26-11-0-final-xxxxx  # DataMasque image tag
         ecrRepo: public  # Use "public" to pull from DataMasque's public ECR, or "private" to use your own ECR
-      masqueVersion: "2.28.0"  # DataMasque version being deployed
+      masqueVersion: "3.26.11.0"  # DataMasque version being deployed
       loggingLevel: "INFO"  # DataMasque logging level
       agentContainer:
         cpu: 2048  # CPU allocation for DataMasque agent container (in units, where 1024 = one vCPU)
@@ -135,7 +133,7 @@ For a private ECR, edit the `ecr` block as follows:
 ```yaml
 ecr:
   ecrRepoName: <prefix>  # Your ECR repo prefix from above
-  ecrImageTag: 2-28-0-final-xxxxx  # DataMasque image tag
+  ecrImageTag: 3-26-11-0-final-xxxxx  # DataMasque image tag
   ecrRepo: private
 ```
 

--- a/cluster-config/ecs.tf
+++ b/cluster-config/ecs.tf
@@ -114,6 +114,7 @@ resource "aws_ecs_service" "datamasque_agent_service" {
   desired_count          = each.value["agentContainer"]["desiredCount"]
   enable_execute_command = true
   launch_type            = "FARGATE"
+  propagate_tags         = "TASK_DEFINITION"
 
   network_configuration {
     subnets         = values(local.common_env_config.subnets)
@@ -180,6 +181,7 @@ resource "aws_ecs_service" "queue_service" {
   desired_count          = 1
   enable_execute_command = true
   launch_type            = "FARGATE"
+  propagate_tags         = "TASK_DEFINITION"
 
   network_configuration {
     subnets         = values(local.common_env_config.subnets)
@@ -326,7 +328,8 @@ resource "aws_ecs_service" "dm_adminserver_service" {
   desired_count          = 1
   enable_execute_command = true
 
-  launch_type = "FARGATE"
+  launch_type    = "FARGATE"
+  propagate_tags = "TASK_DEFINITION"
   service_registries {
     registry_arn = aws_service_discovery_service.admin_server[each.key].arn
   }
@@ -457,6 +460,7 @@ resource "aws_ecs_service" "dm_inflight_service" {
   desired_count          = each.value["inflightContainer"]["desiredCount"]
   enable_execute_command = true
   launch_type            = "FARGATE"
+  propagate_tags         = "TASK_DEFINITION"
   service_registries {
     registry_arn = aws_service_discovery_service.inflight[each.key].arn
   }
@@ -549,6 +553,7 @@ resource "aws_ecs_service" "dm_frontend_service" {
   desired_count          = 1
   enable_execute_command = true
   launch_type            = "FARGATE"
+  propagate_tags         = "TASK_DEFINITION"
   service_registries {
     registry_arn = aws_service_discovery_service.admin_frontend[each.key].arn
   }

--- a/cluster-config/ecs.tf
+++ b/cluster-config/ecs.tf
@@ -26,10 +26,10 @@ resource "aws_ecs_task_definition" "agent_task" {
   container_definitions = jsonencode([
     {
       name              = "${each.key}-agent-worker"
-      image             = "${local.ecr_base_url[each.key]}/agent:${local.ecr_image_url[each.key].image_tag}"
+      image             = "${local.ecr_base_url[each.key]}/app:${local.ecr_image_url[each.key].image_tag}"
       essential         = true
       user              = "1000:1000"
-      entryPoint        = ["/entrypoint.sh"]
+      entryPoint        = ["/entrypoint-agent.sh"]
       cpu               = each.value["agentContainer"]["cpu"]    # Minimum CPU for this container
       memory            = each.value["agentContainer"]["memory"] # Minimum memory for this container
       memoryReservation = 256                                    # Soft memory limit
@@ -206,8 +206,8 @@ resource "aws_ecs_task_definition" "admin_server" {
 
     {
       name       = "${each.key}-admin-server"
-      image      = "${local.ecr_base_url[each.key]}/admin-server:${local.ecr_image_url[each.key].image_tag}"
-      entryPoint = ["/entrypoint.sh"]
+      image      = "${local.ecr_base_url[each.key]}/app:${local.ecr_image_url[each.key].image_tag}"
+      entryPoint = ["/entrypoint-admin-server.sh"]
       essential  = true
       user       = "1000:1000" # Set the user to match EFS access point UID:GID
       logConfiguration = {

--- a/cluster-config/version.tf
+++ b/cluster-config/version.tf
@@ -13,6 +13,10 @@ terraform {
 
 provider "aws" {
   default_tags {
-
+    tags = {
+      # DataMasque AWS PRM (Partner Revenue Measurement) attribution tag. Applied to every
+      # taggable resource this deployment provisions so the self-hosted ECS install is attributed.
+      "aws-apn-id" = "pc:dp9c56sw1n8t10q5s4pxlgl3x"
+    }
   }
 }

--- a/config/example.yml
+++ b/config/example.yml
@@ -7,9 +7,9 @@ ecs:
       albCertificate: xxxx-xxxx-xxxx-xxxx-xxxx  # UUID of the certificate in AWS Certificate Manager
       ecr:
         ecrRepoName: datamasque
-        ecrImageTag: 2-29-0-final-xxxxx  # DataMasque image tag
+        ecrImageTag: 3-26-11-0-final-xxxxx  # DataMasque image tag
         ecrRepo: public  # Use "public" to pull from DataMasque's public ECR, or "private" to use your own ECR
-      masqueVersion: "2.29.0"  # DataMasque version being deployed
+      masqueVersion: "3.26.11.0"  # DataMasque version being deployed
       loggingLevel: "INFO"  # DataMasque logging level
       agentContainer:
         cpu: 2048  # CPU allocation for DataMasque agent container (in units, where 1024 = one vCPU)


### PR DESCRIPTION
- agent and admin-server task definitions now use the datamasque/app image
- bump example ecrImageTag/masqueVersion to the 3.26.11.0 release - the first version shipping the unified image