### PR TITLE
Productionise ECS deployment blueprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+# .github/workflows/ci.yml — Terraform validation for the ECS blueprint.
+# Terraform root is cluster-config/; fmt runs recursively from the repo root.
+name: ci
+on:
+  push: { branches: ["**"] }
+  pull_request:
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    # Config is workspace-named (config/<workspace>.yml); validate against the
+    # committed `example` workspace so locals/CIDRs resolve.
+    env:
+      TF_WORKSPACE: example
+    defaults:
+      run:
+        working-directory: cluster-config
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform fmt -check -recursive
+        working-directory: .
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - uses: terraform-linters/setup-tflint@v4
+      - run: tflint --recursive
+      - uses: bridgecrewio/checkov-action@v12
+        with: { directory: cluster-config, quiet: true, soft_fail: true }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 DataMasque
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-# DataMasque Installation on AWS Elastic Container Service (ECS) Fargate
+# DataMasque on AWS ECS Fargate
+
+> **Reference blueprint — adapt to your environment.** This repository is a
+> starting point, not a turnkey product. Review and harden IAM, networking,
+> secrets, and TLS for your own environment before any production use.
+
+DataMasque replaces sensitive production data with synthetically identical
+customer data, so teams can build and test against production-shaped data
+without exposing PII. This blueprint stands up a self-hosted DataMasque
+instance on **AWS ECS Fargate**, with Terraform provisioning the cluster, an
+EFS persistent layer, an RDS PostgreSQL application database, service
+discovery, and an internal Application Load Balancer. The outcome is a private,
+internally reachable DataMasque install you can run masking jobs from. Both the
+RDS database and the EFS filesystem are encrypted at rest with the default
+AWS-managed KMS key.
+
+**Learn more:** [datamasque.com](https://datamasque.com) ·
+[Product docs](https://datamasque.com/portal/documentation/) ·
+[Book a demo](https://datamasque.com/request-a-demo)
+
+---
 
 ## Getting Started
 
@@ -40,9 +60,9 @@ Before starting the deployment, ensure the following software is installed:
 
 ### Private ECR Setup (Optional)
 
-If using private ECR, create the following Amazon ECR repositories:
+If using private ECR, create the following Amazon ECR repositories
+(these mirror the public ECR images this deployment pulls):
 
-- `<ECR host>/<prefix>/admin-db`
 - `<ECR host>/<prefix>/admin-frontend`
 - `<ECR host>/<prefix>/app`
 - `<ECR host>/<prefix>/agent-queue`
@@ -75,13 +95,16 @@ Below is the example `backend.tf`. Replace the parameter values based on your en
 terraform {
   backend "s3" {
     key            = "datamasque-ecs/tfstate"
-    bucket         = "bucket-name"
+    bucket         = "your-terraform-state-bucket"  # replace with your state bucket
     use_lockfile   = true
     acl            = "bucket-owner-full-control"
     region         = "ap-southeast-2"
   }
 }
 ```
+
+The S3 backend bucket must already exist and is **not** created by this
+Terraform plan.
 
 ### Step 3: Update Configuration Files
 
@@ -103,6 +126,9 @@ ecs:
       dnsNamespace: datamasque  # AWS Cloud Map namespace. NB: It is not possible to change this after deployment.
       rds:
         multiAz: false
+        deletionProtection: false  # Set true to block accidental RDS deletion (recommended for prod)
+        skipFinalSnapshot: true    # Set false to take a final snapshot on destroy
+      maskingBuckets: []  # S3 buckets DataMasque may read/write for file masking. Empty = no S3 access granted.
       albCertificate: xxxx-xxxx-xxxx-xxxx-xxxx  # UUID of the certificate in AWS Certificate Manager
       ecr:
         ecrRepoName: datamasque
@@ -142,6 +168,10 @@ ecr:
 The `config/common_configs.yml` file contains environment-specific VPC, subnet, and network settings.
 Ensure the environment name matches the Terraform workspace name and the name of the deployment parameters file.
 
+> **Prerequisite:** The RDS DB subnet group named in `db_subnetgroup` is looked
+> up, **not created**, by this plan. Create it first (covering the private
+> subnets listed in `subnets`) or the apply will fail to find it.
+
 ```yaml
 production:
   vpcid: "vpc-xxxx"  # VPC ID where DataMasque is being deployed
@@ -180,6 +210,17 @@ The `apply` operation takes about 5-10 minutes.
 
 Once deployed, you can access DataMasque through the Application Load Balancer internal hostname.
 
+## Tearing Down
+
+Run `terraform destroy` to remove the deployment.
+
+> **Irreversible:** `destroy` deletes the RDS instance and the EFS filesystem
+> (including all DataMasque metadata, rulesets, and run history). By default
+> `skip_final_snapshot = true` and `deletion_protection = false`, so **no final
+> snapshot is taken**. For environments you cannot afford to lose, set
+> `rds.deletionProtection: true` and `rds.skipFinalSnapshot: false` in your
+> environment config (see `config/example.yml`) before applying.
+
 ## Next Steps
 
 It is recommended you back up your Terraform configuration files,
@@ -188,3 +229,13 @@ for example in a version control system.
 For more details including IAM permission requirements and detailed troubleshooting steps,
 please refer to the [full DataMasque documentation](https://datamasque.com/portal/documentation/)
 (select your DataMasque version, then **Setup** -> **Installation on Amazon ECS**).
+
+---
+
+## Related DataMasque blueprints
+
+- [AWS RDS masking (Step Functions)](https://github.com/datamasque/DataMasque-AWS-RDS-masking-stepfunctions-blueprint)
+- [Azure DB masking (Logic Apps)](https://github.com/datamasque/DataMasque-Azure-DB-masking-logicapps-blueprint)
+- [AWS Service Catalog DB provisioning](https://github.com/datamasque/DataMasque-AWS-service-catalog-database-provisioning-blueprint)
+- [AWS Cross-Account Bucket Access](https://github.com/datamasque/DataMasque-AWS-Cross-Account-Bucket-Access)
+- [masque-bricks (Databricks)](https://github.com/datamasque/masque-bricks)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+DataMasque takes the security of its software and reference blueprints seriously.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this blueprint, please report it
+privately so we can address it before public disclosure.
+
+- **Email:** security@datamasque.com
+- Include a description of the issue, steps to reproduce, and the affected
+  files or configuration.
+- Please do **not** open a public GitHub issue for security reports.
+
+We will acknowledge your report, investigate, and keep you informed of the
+remediation progress. Responsible disclosure is appreciated.
+
+## Scope
+
+This repository is a **reference blueprint** intended to be adapted to your own
+environment. Review and harden all IAM policies, network rules, secrets
+handling, and TLS settings before any production use.

--- a/cluster-config/alb.tf
+++ b/cluster-config/alb.tf
@@ -1,22 +1,28 @@
 resource "aws_lb" "this" {
-  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
-  name               = "${each.key}-dm-alb"
-  internal           = true
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.alb_sg[each.key].id]
-  subnets            = values(local.common_env_config.subnets)
+  for_each                   = lookup(local.ecs_config["ecs"], "clusters", {})
+  name                       = "${each.key}-dm-alb"
+  internal                   = true
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.alb_sg[each.key].id]
+  subnets                    = values(local.common_env_config.subnets)
   xff_header_processing_mode = "remove"
 }
 
 
 resource "aws_lb_target_group" "this" {
-  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
-  name     = "${each.key}-dm-tg"
-  port     = 8443
-  protocol = "HTTPS"
-  vpc_id   = local.common_env_config.vpcid
+  for_each    = lookup(local.ecs_config["ecs"], "clusters", {})
+  name        = "${each.key}-dm-tg"
+  port        = 8443
+  protocol    = "HTTPS"
+  vpc_id      = local.common_env_config.vpcid
   target_type = "ip"
 
+  # User-facing health gate: the frontend must serve /login as HTTP 200 over
+  # HTTPS or the target is pulled from rotation. Per-container ECS healthCheck
+  # probes for the admin-server / in-flight / frontend tiers are not defined
+  # here — their probe commands depend on image-internal tooling; the ALB check
+  # plus Cloud Map health_check_custom_config cover liveness for the user path.
+  # Add container healthChecks once the image shells/tools are confirmed.
   health_check {
     path                = "/login"
     interval            = 10
@@ -24,16 +30,16 @@ resource "aws_lb_target_group" "this" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     matcher             = "200"
-    protocol = "HTTPS"
+    protocol            = "HTTPS"
   }
 }
 
 resource "aws_lb_listener" "this" {
-  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
+  for_each          = lookup(local.ecs_config["ecs"], "clusters", {})
   load_balancer_arn = aws_lb.this[each.key].arn
   port              = 443
   protocol          = "HTTPS"
-  certificate_arn = "arn:aws:acm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate/${each.value["albCertificate"]}"
+  certificate_arn   = "arn:aws:acm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate/${each.value["albCertificate"]}"
 
   default_action {
     type             = "forward"

--- a/cluster-config/backend.tf
+++ b/cluster-config/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    key            = "datamasque-ecs/tfstate"
-    bucket         = "your-terraform-state-bucket"
-    use_lockfile   = true
-    acl            = "bucket-owner-full-control"
-    region         = "ap-southeast-2"
+    key          = "datamasque-ecs/tfstate"
+    bucket       = "your-terraform-state-bucket"
+    use_lockfile = true
+    acl          = "bucket-owner-full-control"
+    region       = "ap-southeast-2"
   }
 }

--- a/cluster-config/cloudwatch.tf
+++ b/cluster-config/cloudwatch.tf
@@ -1,5 +1,7 @@
 resource "aws_cloudwatch_log_group" "ecs_log_group" {
-  for_each          = lookup(local.ecs_config["ecs"], "clusters", {})
-  name              = "/ecs/${each.key}"
-  retention_in_days = 7 # Optional: Retain logs for 7 days
+  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
+  name     = "/ecs/${each.key}"
+  # Default 7 days for disposable environments; raise via logRetentionDays in
+  # the environment config for compliance/audit retention.
+  retention_in_days = lookup(each.value, "logRetentionDays", 7)
 }

--- a/cluster-config/ecs.tf
+++ b/cluster-config/ecs.tf
@@ -25,14 +25,13 @@ resource "aws_ecs_task_definition" "agent_task" {
 
   container_definitions = jsonencode([
     {
-      name              = "${each.key}-agent-worker"
-      image             = "${local.ecr_base_url[each.key]}/app:${local.ecr_image_url[each.key].image_tag}"
-      essential         = true
-      user              = "1000:1000"
-      entryPoint        = ["/entrypoint-agent.sh"]
-      cpu               = each.value["agentContainer"]["cpu"]    # Minimum CPU for this container
-      memory            = each.value["agentContainer"]["memory"] # Minimum memory for this container
-      memoryReservation = 256                                    # Soft memory limit
+      name       = "${each.key}-agent-worker"
+      image      = "${local.ecr_base_url[each.key]}/app:${local.ecr_image_url[each.key].image_tag}"
+      essential  = true
+      user       = "1000:1000"
+      entryPoint = ["/entrypoint-agent.sh"]
+      cpu        = each.value["agentContainer"]["cpu"]    # Minimum CPU for this container
+      memory     = each.value["agentContainer"]["memory"] # Minimum memory for this container
       environment = [
         { name = "LOGLEVEL", value = each.value["loggingLevel"] },
         { name = "MASQUE_SANDBOX_PATH", value = "/files/user/" },
@@ -118,7 +117,7 @@ resource "aws_ecs_service" "datamasque_agent_service" {
 
   network_configuration {
     subnets         = values(local.common_env_config.subnets)
-    security_groups = [aws_security_group.ecs_sg[each.key].id] # Replace with your security group
+    security_groups = [aws_security_group.ecs_sg[each.key].id]
   }
   service_registries {
     registry_arn = aws_service_discovery_service.agent[each.key].arn
@@ -147,6 +146,14 @@ resource "aws_ecs_task_definition" "agent_queue" {
         containerPort = 6379
         hostPort      = 6379
       }]
+      # The queue is a Redis service on 6379; redis-cli ships in the image.
+      healthCheck = {
+        command     = ["CMD-SHELL", "redis-cli ping | grep -q PONG || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 30
+      }
 
       environment = [
         {
@@ -231,7 +238,7 @@ resource "aws_ecs_task_definition" "admin_server" {
         { name = "MASQUE_ADMIN_DB_NAME", value = "postgres" },
         { name = "MASQUE_ADMIN_DB_USER", value = "postgres" },
         { name = "MASQUE_HOST_SUFFIX", value = lookup(each.value, "dnsNamespace", "internal") },
-        { name = "MASQUE_ADMIN_DB_HOST", value = "${aws_db_instance.dm_pgdb[each.key].address}" }, ##change it to FQDN
+        { name = "MASQUE_ADMIN_DB_HOST", value = aws_db_instance.dm_pgdb[each.key].address },
         { name = "MASQUE_ADMIN_DB_PORT", value = tostring(aws_db_instance.dm_pgdb[each.key].port) },
         { name = "MASQUE_SANDBOX_PATH", value = "/files/user/" },
         {
@@ -259,18 +266,6 @@ resource "aws_ecs_task_definition" "admin_server" {
 
   volume {
     name = "license"
-    efs_volume_configuration {
-      file_system_id     = aws_efs_file_system.datamasque_efs[each.key].id
-      transit_encryption = "ENABLED"
-      authorization_config {
-        access_point_id = aws_efs_access_point.dm_efs_access_point[each.key].id
-        iam             = "ENABLED"
-      }
-    }
-  }
-
-  volume {
-    name = "certs"
     efs_volume_configuration {
       file_system_id     = aws_efs_file_system.datamasque_efs[each.key].id
       transit_encryption = "ENABLED"
@@ -337,7 +332,7 @@ resource "aws_ecs_service" "dm_adminserver_service" {
   network_configuration {
     subnets          = values(local.common_env_config.subnets)
     assign_public_ip = false
-    security_groups  = [aws_security_group.ecs_sg[each.key].id] # Replace with your security group
+    security_groups  = [aws_security_group.ecs_sg[each.key].id]
   }
 }
 
@@ -391,18 +386,6 @@ resource "aws_ecs_task_definition" "in_flight_server" {
   }])
   volume {
     name = "license"
-    efs_volume_configuration {
-      file_system_id     = aws_efs_file_system.datamasque_efs[each.key].id
-      transit_encryption = "ENABLED"
-      authorization_config {
-        access_point_id = aws_efs_access_point.dm_efs_access_point[each.key].id
-        iam             = "ENABLED"
-      }
-    }
-  }
-
-  volume {
-    name = "certs"
     efs_volume_configuration {
       file_system_id     = aws_efs_file_system.datamasque_efs[each.key].id
       transit_encryption = "ENABLED"
@@ -468,7 +451,7 @@ resource "aws_ecs_service" "dm_inflight_service" {
   network_configuration {
     subnets          = values(local.common_env_config.subnets)
     assign_public_ip = false
-    security_groups  = [aws_security_group.ecs_sg[each.key].id] # Replace with your security group
+    security_groups  = [aws_security_group.ecs_sg[each.key].id]
   }
 }
 
@@ -489,8 +472,8 @@ resource "aws_ecs_task_definition" "frontend_server" {
       name       = "${each.key}-admin-frontend"
       image      = "${local.ecr_base_url[each.key]}/admin-frontend:${local.ecr_image_url[each.key].image_tag}"
       entryPoint = ["/entrypoint.sh"]
-      essential = true
-      user      = "1000:1000"
+      essential  = true
+      user       = "1000:1000"
       logConfiguration = {
         logDriver = "awslogs"
         options = {
@@ -506,7 +489,6 @@ resource "aws_ecs_task_definition" "frontend_server" {
       environment = [
         { name = "HOST_IP", value = "127.0.0.1" },
         { name = "MASQUE_VERSION", value = each.value["masqueVersion"] },
-        # { name = "MASQUE_HOST_SUFFIX", value = lookup(each.value, "dnsNamespace", ".internal") }
         { name = "MASQUE_ADMIN_SERVER_HOST", value = "admin-server.${lookup(each.value, "dnsNamespace", "internal")}" },
         { name = "MASQUE_IN_FLIGHT_SERVER_HOST", value = "in-flight-server.${lookup(each.value, "dnsNamespace", "internal")}" },
         { name = "MASQUE_ADMIN_FRONTEND_HOST", value = "localhost" }
@@ -565,9 +547,9 @@ resource "aws_ecs_service" "dm_frontend_service" {
     container_port   = 8443
   }
 
-  network_configuration { 
+  network_configuration {
     subnets          = values(local.common_env_config.subnets)
     assign_public_ip = false
-    security_groups  = [aws_security_group.ecs_sg[each.key].id] # Replace with your security group
+    security_groups  = [aws_security_group.ecs_sg[each.key].id]
   }
 }

--- a/cluster-config/efs.tf
+++ b/cluster-config/efs.tf
@@ -1,5 +1,5 @@
 resource "aws_efs_file_system" "datamasque_efs" {
-  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
+  for_each       = lookup(local.ecs_config["ecs"], "clusters", {})
   creation_token = "${each.key}-efs"
   encrypted      = true
   tags = {
@@ -46,27 +46,12 @@ resource "aws_efs_access_point" "dm_efs_access_point" {
   root_directory {
     path = "/datamasque/app"
     creation_info {
-      owner_uid   = 1000
-      owner_gid   = 1000
-      permissions = 777
-    }
-  }
-
-}
-
-resource "aws_efs_access_point" "dm_efs_access_point_admindb" {
-  for_each       = lookup(local.ecs_config["ecs"], "clusters", {})
-  file_system_id = aws_efs_file_system.datamasque_efs[each.key].id
-  posix_user {
-    gid = 999
-    uid = 999
-  }
-  root_directory {
-    path = "/datamasque/pgdata"
-    creation_info {
-      owner_uid   = 999
-      owner_gid   = 999
-      permissions = 777
+      owner_uid = 1000
+      owner_gid = 1000
+      # 770: owner (uid 1000) and group (gid 1000) get full rwx; no world
+      # access. All DataMasque containers run as 1000:1000, so they retain
+      # full read/write while world access is dropped.
+      permissions = 770
     }
   }
 

--- a/cluster-config/iam.tf
+++ b/cluster-config/iam.tf
@@ -49,6 +49,9 @@ resource "aws_iam_role_policy" "ecs_task_execution_policy" {
         Resource = aws_secretsmanager_secret.datamasque_postgres[each.key].arn
       },
       {
+        # ECS Exec (SSM Session Manager) channel actions do not support
+        # resource-level scoping; "*" is required by AWS. Needed for
+        # `enable_execute_command` shell access into tasks. Intentional wildcard.
         "Sid" : "SSM",
         "Effect" : "Allow",
         "Action" : [
@@ -94,7 +97,12 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
   role     = aws_iam_role.ecs_task_role[each.key].id
   policy = jsonencode({
     Version = "2012-10-17",
-    Statement = [
+    # S3 access for file masking is scoped to the buckets listed in each
+    # cluster's `maskingBuckets` config (see config/example.yml). When the list
+    # is empty the S3 statements are omitted entirely (an empty Resource list is
+    # rejected by IAM), so the default deployment carries no S3 permissions
+    # until you name the buckets it must read masked/source files from.
+    Statement = concat([
       {
         Effect = "Allow",
         Action = [
@@ -106,6 +114,9 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
         Resource = aws_efs_access_point.dm_efs_access_point[each.key].arn
       },
       {
+        # ECS Exec (SSM Session Manager) channel actions do not support
+        # resource-level scoping; "*" is required by AWS. Needed for
+        # `enable_execute_command` shell access into tasks. Intentional wildcard.
         "Sid" : "SSM",
         "Effect" : "Allow",
         "Action" : [
@@ -117,27 +128,10 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
         "Resource" : ["*"]
       },
       {
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketAcl",
-          "s3:GetBucketPolicyStatus",
-          "s3:GetBucketPublicAccessBlock",
-          "s3:GetBucketObjectLockConfiguration",
-          "s3:GetEncryptionConfiguration"
-        ],
-        Resource = ["arn:aws:s3:::*"]
-      },
-      {
-        "Sid" : "BucketReadWrite",
-        "Effect" : "Allow",
-        "Action" : [
-          "s3:PutObject",
-          "s3:GetObject"
-        ],
-        "Resource" : ["arn:aws:s3:::*/*"]
-      },
-      {
+        # ListSecrets has no resource-level scoping in IAM (AWS requires "*"),
+        # so this stays a wildcard by necessity. It is metadata-only (names/ARNs,
+        # never values); DataMasque uses it to enumerate connection secrets in
+        # the console. Remove this statement if you wire connections by ARN only.
         "Sid" : "DataMasqueListSecrets",
         "Effect" : "Allow",
         "Action" : [
@@ -146,14 +140,24 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
         "Resource" : "*"
       },
       {
+        # GetSecretValue is scoped to this deployment's secret name prefix in
+        # this account/region. The masking agent only needs to read the DB
+        # password and any DataMasque connection secrets it provisions, all of
+        # which share the `<cluster>-dm-` / `datamasque` naming prefix.
         "Sid" : "AllowSecretRead",
         "Effect" : "Allow",
         "Action" : [
           "secretsmanager:GetSecretValue"
         ],
-        "Resource" : "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*"
+        "Resource" : [
+          "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${each.key}-dm-*",
+          "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:datamasque*"
+        ]
       },
       {
+        # license-manager Checkout/CheckIn operate on AWS-managed license
+        # configurations and do not accept resource-level scoping; "*" is the
+        # only valid resource for these actions. Intentionally left wildcard.
         "Sid" : "DataMasqueLicenseCheckInAndOut",
         "Effect" : "Allow",
         "Action" : [
@@ -163,6 +167,10 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
         "Resource" : "*"
       },
       {
+        # Step Functions automation: state machine ARNs are created by the
+        # operator outside this plan and are not known at apply time, so these
+        # list/start actions stay wildcard. Narrow to specific state-machine
+        # ARNs if you pre-create them.
         "Sid" : "DataMasqueStepFunctionAutomation",
         "Effect" : "Allow",
         "Action" : [
@@ -173,6 +181,9 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
         "Resource" : "*"
       },
       {
+        # ecs:ListTasks/DescribeTasks do not support resource-level permissions
+        # for listing across a cluster; AWS requires "*". Read-only task
+        # introspection used by the agent. Intentionally left wildcard.
         "Sid" : "DataMasqueQueryTasks",
         "Effect" : "Allow",
         "Action" : [
@@ -181,6 +192,34 @@ resource "aws_iam_role_policy" "ecs_task_access_policy" {
         ],
         "Resource" : "*"
       }
-    ]
+      ], flatten([
+        # The S3 statements are included only when maskingBuckets is non-empty.
+        # range() yields a consistently-typed list(number) ([0] or []), so this
+        # gate avoids the "inconsistent conditional result types" error that a
+        # `? [stmt1, stmt2] : []` ternary raises (2-element vs 0-element tuple).
+        for _ in range(length(lookup(each.value, "maskingBuckets", [])) > 0 ? 1 : 0) : [
+          {
+            Effect = "Allow",
+            Action = [
+              "s3:ListBucket",
+              "s3:GetBucketAcl",
+              "s3:GetBucketPolicyStatus",
+              "s3:GetBucketPublicAccessBlock",
+              "s3:GetBucketObjectLockConfiguration",
+              "s3:GetEncryptionConfiguration"
+            ],
+            Resource = [for b in each.value["maskingBuckets"] : "arn:aws:s3:::${b}"]
+          },
+          {
+            "Sid" : "BucketReadWrite",
+            "Effect" : "Allow",
+            "Action" : [
+              "s3:PutObject",
+              "s3:GetObject"
+            ],
+            "Resource" : [for b in each.value["maskingBuckets"] : "arn:aws:s3:::${b}/*"]
+          }
+        ]
+    ]))
   })
 }

--- a/cluster-config/locals.tf
+++ b/cluster-config/locals.tf
@@ -18,8 +18,8 @@ locals {
   # Private ECR: `<account ID>.dkr.ecr.<region>.amazonaws.com/<repo prefix>`
   ecr_base_url = {
     for cluster_key in keys(local.ecr_image_url) : cluster_key =>
-      local.ecr_image_url[cluster_key].is_public ?
-        "public.ecr.aws/${local.ecr_image_url[cluster_key].repo_base}" :
-        "${local.ecr_image_url[cluster_key].account_id}.dkr.ecr.${local.ecr_image_url[cluster_key].region}.amazonaws.com/${local.ecr_image_url[cluster_key].repo_base}"
+    local.ecr_image_url[cluster_key].is_public ?
+    "public.ecr.aws/${local.ecr_image_url[cluster_key].repo_base}" :
+    "${local.ecr_image_url[cluster_key].account_id}.dkr.ecr.${local.ecr_image_url[cluster_key].region}.amazonaws.com/${local.ecr_image_url[cluster_key].repo_base}"
   }
 }

--- a/cluster-config/rds.tf
+++ b/cluster-config/rds.tf
@@ -4,21 +4,26 @@ data "aws_db_subnet_group" "dm" {
 }
 
 resource "aws_db_instance" "dm_pgdb" {
-  for_each   = lookup(local.ecs_config["ecs"], "clusters", {})
-  identifier = "${each.key}-pg-dm-rds"
-  engine     = "postgres"
-  instance_class             = "db.t4g.micro" # e.g. db.t4g.small
-  allocated_storage          = 20             # GiB
-  storage_type               = "gp3"
-  username                   = "postgres" # e.g. "postgres"
-  password                   = jsondecode(aws_secretsmanager_secret_version.datamasque_postgres_version[each.key].secret_string)["POSTGRES_PASSWORD"]
-  db_name                    = "postgres" # initial database name
-  db_subnet_group_name       = data.aws_db_subnet_group.dm.name
-  vpc_security_group_ids     = [aws_security_group.rds_sg[each.key].id]
-  publicly_accessible        = false
-  multi_az                   = each.value["rds"]["multiAz"]
-  skip_final_snapshot        = true
-  deletion_protection        = false
+  for_each               = lookup(local.ecs_config["ecs"], "clusters", {})
+  identifier             = "${each.key}-pg-dm-rds"
+  engine                 = "postgres"
+  instance_class         = "db.t4g.micro" # e.g. db.t4g.small
+  allocated_storage      = 20             # GiB
+  storage_type           = "gp3"
+  username               = "postgres" # e.g. "postgres"
+  password               = jsondecode(aws_secretsmanager_secret_version.datamasque_postgres_version[each.key].secret_string)["POSTGRES_PASSWORD"]
+  db_name                = "postgres" # initial database name
+  db_subnet_group_name   = data.aws_db_subnet_group.dm.name
+  vpc_security_group_ids = [aws_security_group.rds_sg[each.key].id]
+  publicly_accessible    = false
+  storage_encrypted      = true # encrypt DataMasque metadata at rest (uses the default AWS-managed KMS key)
+  multi_az               = each.value["rds"]["multiAz"]
+  # Defaults preserve the original blueprint behaviour (no snapshot, no
+  # protection) for easy teardown of disposable environments. Set
+  # rds.skipFinalSnapshot: false and rds.deletionProtection: true in the
+  # environment config to protect data you cannot afford to lose.
+  skip_final_snapshot        = lookup(each.value["rds"], "skipFinalSnapshot", true)
+  deletion_protection        = lookup(each.value["rds"], "deletionProtection", false)
   auto_minor_version_upgrade = true
 
   tags = {

--- a/cluster-config/secrets.tf
+++ b/cluster-config/secrets.tf
@@ -1,7 +1,7 @@
 
 resource "random_password" "masque_admin_db_password" {
   for_each         = lookup(local.ecs_config["ecs"], "clusters", {})
-  length           = 8       # Length of the password
+  length           = 24      # Length of the password
   special          = true    # Include special characters
   upper            = true    # Include uppercase letters
   lower            = true    # Include lowercase letters
@@ -11,9 +11,11 @@ resource "random_password" "masque_admin_db_password" {
 
 # Store the password in AWS Secrets Manager
 resource "aws_secretsmanager_secret" "datamasque_postgres" {
-  for_each                = lookup(local.ecs_config["ecs"], "clusters", {})
-  name                    = "${each.key}-dm-ecs-db-password"
-  recovery_window_in_days = 0
+  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
+  name     = "${each.key}-dm-ecs-db-password"
+  # Retain deleted secrets for a recovery window instead of immediate purge, so
+  # an accidental destroy can be undone within the window.
+  recovery_window_in_days = 7
 }
 
 resource "aws_secretsmanager_secret_version" "datamasque_postgres_version" {

--- a/cluster-config/security_group.tf
+++ b/cluster-config/security_group.tf
@@ -38,13 +38,13 @@ resource "aws_security_group" "ecs_sg" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ecs_sg_ingress_https" {
-  for_each          = lookup(local.ecs_config["ecs"], "clusters", {})
-  security_group_id = aws_security_group.ecs_sg[each.key].id
-  referenced_security_group_id         = aws_security_group.alb_sg[each.key].id
-  from_port         = 8443
-  ip_protocol       = "tcp"
-  to_port           = 8443
-  description       = "Allow HTTPS traffic"
+  for_each                     = lookup(local.ecs_config["ecs"], "clusters", {})
+  security_group_id            = aws_security_group.ecs_sg[each.key].id
+  referenced_security_group_id = aws_security_group.alb_sg[each.key].id
+  from_port                    = 8443
+  ip_protocol                  = "tcp"
+  to_port                      = 8443
+  description                  = "Allow HTTPS traffic"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ecs_sg_ingress_https2" {
@@ -85,6 +85,8 @@ resource "aws_vpc_security_group_ingress_rule" "rds_sg_ingress_https2" {
   description                  = "Allow traffic from DataMasque instance"
 }
 
+# RDS egress is unrestricted, but the instance is publicly_accessible = false
+# and its ingress only admits the ECS SG. Tighten if your policy requires it.
 resource "aws_vpc_security_group_egress_rule" "rds_sg_egress" {
   for_each          = lookup(local.ecs_config["ecs"], "clusters", {})
   security_group_id = aws_security_group.rds_sg[each.key].id
@@ -94,6 +96,9 @@ resource "aws_vpc_security_group_egress_rule" "rds_sg_egress" {
   to_port           = -1
 }
 
+# ECS tasks need outbound to ECR (image pull), Secrets Manager, AWS License
+# Manager, CloudWatch, and the customer databases being masked, so egress is
+# left open. Restrict to known destinations if your masking targets are fixed.
 resource "aws_vpc_security_group_egress_rule" "ecs_sg_egress" {
   for_each          = lookup(local.ecs_config["ecs"], "clusters", {})
   security_group_id = aws_security_group.ecs_sg[each.key].id

--- a/cluster-config/service_discovery.tf
+++ b/cluster-config/service_discovery.tf
@@ -35,21 +35,6 @@ resource "aws_service_discovery_service" "admin_server" {
   }
 }
 
-resource "aws_service_discovery_service" "admin_db" {
-  for_each = lookup(local.ecs_config["ecs"], "clusters", {})
-  name     = "admin-db"
-  dns_config {
-    namespace_id = aws_service_discovery_private_dns_namespace.local[each.key].id
-    dns_records {
-      ttl  = 20
-      type = "A"
-    }
-  }
-  health_check_custom_config {
-    failure_threshold = 1
-  }
-}
-
 resource "aws_service_discovery_service" "queue" {
   for_each = lookup(local.ecs_config["ecs"], "clusters", {})
   name     = "agent-queue"

--- a/cluster-config/version.tf
+++ b/cluster-config/version.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/config/common_configs.yml
+++ b/config/common_configs.yml
@@ -1,7 +1,7 @@
 example:
   vpcid: "vpc-xxxx"  # VPC ID where DataMasque being deployed
   db_subnetgroup: "db subnet group"  # Name of the db subnet group to deploy RDS
-  inbound_cidr_range: 10.x.x.x/x  # CIDR range to allow connections to DataMasque application
+  inbound_cidr_range: 10.0.0.0/16  # REPLACE: source CIDR allowed to reach DataMasque. Scope to your admin/VPN range; the example /16 is deliberately broad.
   subnets:  # Subnet IDs in the VPC
     subneta: "subnet-0axxxx"  # a private subnet
     subnetb: "subnet-0bxxxx"  # b private subnet

--- a/config/example.yml
+++ b/config/example.yml
@@ -4,6 +4,9 @@ ecs:
       dnsNamespace: datamasque  # AWS Cloud Map namespace. NB: It is not possible to change this after deployment.
       rds:
         multiAz: false
+        deletionProtection: false  # Set true to block accidental RDS deletion (recommended for prod)
+        skipFinalSnapshot: true    # Set false to take a final snapshot on destroy
+      maskingBuckets: []  # S3 bucket names DataMasque may read/write for file masking, e.g. [my-source-bucket, my-masked-bucket]. Empty = no S3 access.
       albCertificate: xxxx-xxxx-xxxx-xxxx-xxxx  # UUID of the certificate in AWS Certificate Manager
       ecr:
         ecrRepoName: datamasque
@@ -11,6 +14,7 @@ ecs:
         ecrRepo: public  # Use "public" to pull from DataMasque's public ECR, or "private" to use your own ECR
       masqueVersion: "3.26.11.0"  # DataMasque version being deployed
       loggingLevel: "INFO"  # DataMasque logging level
+      logRetentionDays: 7  # CloudWatch log retention (days). Raise for compliance/audit retention.
       agentContainer:
         cpu: 2048  # CPU allocation for DataMasque agent container (in units, where 1024 = one vCPU)
         memory: 4096  # Memory allocation for DataMasque agent container (in MB)


### PR DESCRIPTION
Hardens the ECS Fargate deployment blueprint for public, self-served use.

Add LICENSE, SECURITY.md, reframed README + CTA + sibling links, CI (terraform fmt/validate/tflint/checkov).

**Fixes:**
- Scoped task-role S3 + Secrets Manager IAM off wildcards; commented the intentional ones
- DB password length 8→24; secret recovery window >0; EFS access points 777→770
- Parameterised RDS deletion_protection/skip_final_snapshot; removed dead resources
- Added container health check; parameterised log retention
