### PR TITLE
feat: DM-3946 size the agent task's disk for table references

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ ecs:
         cpu: 2048  # CPU allocation for DataMasque agent container (in units, where 1024 = one vCPU)
         memory: 4096  # Memory allocation for DataMasque agent container (in MB)
         desiredCount: 1  # Number of agent containers to deploy
+        tableReferenceStorageGiB: 20  # Disk that table references are stored in. The task's ephemeral storage is sized to this plus 5 GiB of headroom, or to the 21 GiB Fargate requires at the least.
       inflightContainer:
         cpu: 512  # CPU allocation for DataMasque inflight container (in units)
         memory: 2048  # Memory allocation for DataMasque inflight container (in MB)

--- a/cluster-config/ecs.tf
+++ b/cluster-config/ecs.tf
@@ -23,6 +23,10 @@ resource "aws_ecs_task_definition" "agent_task" {
   task_role_arn            = aws_iam_role.ecs_task_role[each.key].arn
   execution_role_arn       = aws_iam_role.ecs_task_execution_role[each.key].arn
 
+  ephemeral_storage {
+    size_in_gib = local.agent_ephemeral_storage_gib[each.key]
+  }
+
   container_definitions = jsonencode([
     {
       name       = "${each.key}-agent-worker"
@@ -37,7 +41,8 @@ resource "aws_ecs_task_definition" "agent_task" {
         { name = "MASQUE_SANDBOX_PATH", value = "/files/user/" },
         { name = "MASQUE_ENV", value = "prod" },
         { name = "MASQUE_VERSION", value = each.value["masqueVersion"] },
-        { name = "MASQUE_HOST_SUFFIX", value = lookup(each.value, "dnsNamespace", "internal") }
+        { name = "MASQUE_HOST_SUFFIX", value = lookup(each.value, "dnsNamespace", "internal") },
+        { name = "MASQUE_TABLE_REFERENCE_STORAGE", value = "${local.agent_table_reference_storage_gib[each.key]}Gi" }
       ]
 
       mountPoints = [

--- a/cluster-config/locals.tf
+++ b/cluster-config/locals.tf
@@ -22,4 +22,17 @@ locals {
     "public.ecr.aws/${local.ecr_image_url[cluster_key].repo_base}" :
     "${local.ecr_image_url[cluster_key].account_id}.dkr.ecr.${local.ecr_image_url[cluster_key].region}.amazonaws.com/${local.ecr_image_url[cluster_key].repo_base}"
   }
+
+  agent_table_reference_storage_gib = {
+    for cluster_key, cluster_config in lookup(local.ecs_config["ecs"], "clusters", {}) :
+    cluster_key => lookup(cluster_config["agentContainer"], "tableReferenceStorageGiB", 20)
+  }
+
+  agent_ephemeral_storage_headroom_gib = 5
+
+  # Fargate refuses an ephemeral storage size below 21 GiB.
+  agent_ephemeral_storage_gib = {
+    for cluster_key, storage_gib in local.agent_table_reference_storage_gib :
+    cluster_key => max(21, storage_gib + local.agent_ephemeral_storage_headroom_gib)
+  }
 }

--- a/config/example.yml
+++ b/config/example.yml
@@ -19,6 +19,7 @@ ecs:
         cpu: 2048  # CPU allocation for DataMasque agent container (in units, where 1024 = one vCPU)
         memory: 4096  # Memory allocation for DataMasque agent container (in MB)
         desiredCount: 1  # Number of agent containers to deploy
+        tableReferenceStorageGiB: 20  # Disk that table references are stored in. The task's ephemeral storage is sized to this plus 5 GiB of headroom, or to the 21 GiB Fargate requires at the least.
       inflightContainer:
         cpu: 512  # CPU allocation for DataMasque inflight container (in units)
         memory: 2048  # Memory allocation for DataMasque inflight container (in MB)


### PR DESCRIPTION
Table references are downloaded to the agent container's ephemeral storage and kept there for the duration of a run,
so the task needs disk sized for them and the agent needs to know how much it may use.

- `agentContainer.tableReferenceStorageGiB` (default `20`) sets how much disk table references may occupy.
- The agent task's `ephemeral_storage` is sized to that value plus 5 GiB of headroom
  for the application image, the container's writable layer and scratch files.
- The same value is passed to the agent as `MASQUE_TABLE_REFERENCE_STORAGE`,
  so the agent refuses an over-large table reference up front
  rather than filling the task's disk.

Deriving both from one config value keeps the agent's limit and the disk it actually has in step.

### Note on cost

Fargate includes 20 GiB of ephemeral storage per task and bills above that.
The default here sizes the task at 25 GiB, so it adds roughly 5 GB of chargeable ephemeral storage per agent task.
Lower `tableReferenceStorageGiB` if your table references are small
and you would rather stay closer to the included amount.

### Verification

`terraform fmt -check -recursive cluster-config` passes.
`terraform validate` has not been run here, as it needs provider initialisation.